### PR TITLE
Switch Ubuntu base image to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:22.04 as build
 
 LABEL maintainer="SDF Ops Team <ops@stellar.org>"
 


### PR DESCRIPTION
### What

Switch Ubuntu to 22.04 from 20.04
### Why

We are moving other images to 22.04, this change improves consistency across SDF docker images.
